### PR TITLE
Drop `cljsjs` react in favour of node modules, and up Clojure version to latest

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,17 +2,17 @@
  ["src"]
 
  :deps
- {cljsjs/highlight                  {:mvn/version "9.12.0-2"}
-  cljsjs/react-grid-layout          {:mvn/version "0.16.6-0"}
-  com.fulcrologic/fulcro            {:mvn/version "3.0.6"}
-  com.fulcrologic/fulcro-garden-css {:mvn/version "3.0.6"}
+ {com.fulcrologic/fulcro            {:mvn/version "3.0.6"}
+  ;com.fulcrologic/fulcro-garden-css {:mvn/version "3.0.6"}
+  com.fulcrologic/fulcro-garden-css {:git/url "https://github.com/danieroux/fulcro-garden-css"
+                                     :sha     "8af3768ac5c766c22987df08ed8df609e1471692"}
   com.wsscode/fuzzy                 {:mvn/version "1.0.0"}
   org.clojure/core.async            {:mvn/version "0.4.490"}}
 
  :aliases
  {:provided
   {:extra-deps
-   {org.clojure/clojure       {:mvn/version "1.9.0"}
+   {org.clojure/clojure       {:mvn/version "1.11.1"}
     org.clojure/clojurescript {:mvn/version "1.10.520"}
     thheller/shadow-cljs      {:mvn/version "2.10.9"}}}
 

--- a/src/nubank/workspaces/card_types/fulcro3.cljs
+++ b/src/nubank/workspaces/card_types/fulcro3.cljs
@@ -14,7 +14,8 @@
     [nubank.workspaces.data :as data]
     [nubank.workspaces.model :as wsm]
     [nubank.workspaces.ui :as ui]
-    [nubank.workspaces.ui.core :as uc]))
+    [nubank.workspaces.ui.core :as uc]
+    ["react-dom" :as ReactDOM]))
 
 ; region portal
 
@@ -132,7 +133,7 @@
      (let [app (gobj/get this "app")]
        (dispose-app app)
        (reset! app nil)
-       (js/ReactDOM.unmountComponentAtNode (dom/node this))))
+       (ReactDOM.unmountComponentAtNode (dom/node this))))
 
    :shouldComponentUpdate
    (fn [this _ _] false)}
@@ -182,7 +183,7 @@
       {::wsm/dispose
        (fn [node]
          (dispose-app app)
-         (js/ReactDOM.unmountComponentAtNode node))
+         (ReactDOM.unmountComponentAtNode node))
 
        ::wsm/refresh
        (fn [_]

--- a/src/nubank/workspaces/card_types/react.cljs
+++ b/src/nubank/workspaces/card_types/react.cljs
@@ -2,14 +2,14 @@
   (:require-macros [nubank.workspaces.card-types.react])
   (:require [nubank.workspaces.model :as wsm]
             [nubank.workspaces.card-types.util :as ct.util]
-            [cljsjs.react.dom]
+            ["react-dom" :as ReactDOM]
             [goog.object :as gobj]
             [nubank.workspaces.data :as data]
             [nubank.workspaces.ui :as ui]))
 
 (defn render-at [c node]
   (let [comp (if (fn? c) (c) c)]
-    (js/ReactDOM.render comp node)))
+    (ReactDOM.render comp node)))
 
 (defn react-card-init [{::wsm/keys [card-id]
                         :as        card} state-atom component]
@@ -19,7 +19,7 @@
        (if state-atom
          (remove-watch state-atom ::card-watch))
 
-       (js/ReactDOM.unmountComponentAtNode node))
+       (ReactDOM.unmountComponentAtNode node))
 
      ::wsm/refresh
      (fn [node]

--- a/src/nubank/workspaces/card_types/test.cljs
+++ b/src/nubank/workspaces/card_types/test.cljs
@@ -3,7 +3,7 @@
     [cljs.core.async :as async :refer [go chan go-loop put! close! <!]]
     [cljs.reader :refer [read-string]]
     [cljs.test]
-    [cljsjs.react.dom]
+    ["react-dom"]
     [clojure.data]
     [com.fulcrologic.fulcro-css.css :as css]
     [com.fulcrologic.fulcro-css.localized-dom :as dom]

--- a/src/nubank/workspaces/ui/grid_layout.cljs
+++ b/src/nubank/workspaces/ui/grid_layout.cljs
@@ -3,7 +3,7 @@
             [com.fulcrologic.fulcro-css.localized-dom :as dom]
             [garden.selectors :as gs]
             [goog.object :as gobj]
-            [cljsjs.react-grid-layout]
+            ["react-grid-layout" :as ReactGridLayout]
             [nubank.workspaces.ui.core :as uc]))
 
 (def column-size 120)
@@ -23,8 +23,8 @@
    [(gs/& (gs/not :.react-grid-placeholder))
     props]])
 
-(def WidthProvider js/ReactGridLayout.WidthProvider)
-(def Responsive js/ReactGridLayout.Responsive)
+(def WidthProvider ReactGridLayout.WidthProvider)
+(def Responsive ReactGridLayout.Responsive)
 
 (def GridWithWidth (WidthProvider Responsive))
 

--- a/src/nubank/workspaces/ui/highlight.cljs
+++ b/src/nubank/workspaces/ui/highlight.cljs
@@ -1,12 +1,12 @@
 (ns nubank.workspaces.ui.highlight
   (:require [com.fulcrologic.fulcro.components :as fp]
             [com.fulcrologic.fulcro-css.localized-dom :as dom]
-            [cljsjs.highlight]))
+            ["highlight.js" :as hljs]))
 
 (fp/defsc Highlight [this {::keys [source language]}]
   {:componentDidMount
    (fn [this]
-     (js/hljs.highlightBlock (dom/node this)))}
+     (hljs.highlightBlock (dom/node this)))}
 
   (dom/pre {:className (or language "clojure")} source))
 

--- a/src/nubank/workspaces/ui/modal.cljs
+++ b/src/nubank/workspaces/ui/modal.cljs
@@ -4,10 +4,11 @@
             [goog.style :as style]
             [com.fulcrologic.fulcro-css.localized-dom :as dom]
             [com.fulcrologic.fulcro.components :as fp]
-            [nubank.workspaces.ui.events :as events]))
+            [nubank.workspaces.ui.events :as events]
+            ["react-dom" :as ReactDOM]))
 
 (defn render-subtree-into-container [parent c node]
-  (js/ReactDOM.unstable_renderSubtreeIntoContainer parent c node))
+  (ReactDOM.unstable_renderSubtreeIntoContainer parent c node))
 
 (defn $ [s] (.querySelector js/document s))
 
@@ -33,7 +34,7 @@
    :componentWillUnmount
    (fn [this]
      (when-let [node (gobj/get this "node")]
-       (js/ReactDOM.unmountComponentAtNode node)
+       (ReactDOM.unmountComponentAtNode node)
        (gdom/removeNode node)))
 
    :componentWillReceiveProps


### PR DESCRIPTION
- Depend on a patched `fulcro-garden-css`, so `deps.edn` is incorrect.
- This PR will create a new dep: https://github.com/fulcrologic/fulcro-garden-css/pull/16
- Clojure 1.10 features used in codebase